### PR TITLE
Fix inline keyboard callback pattern

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -1236,7 +1236,9 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("removeword", cmd_removeword))
     app.add_handler(CommandHandler("checkword", cmd_checkword))
 
-    # Обработчики callback-ов и сообщений (расширенные паттерны)
+    # Обработчики callback-ов. Шаблон покрывает все callback_data,
+    # используемые в интерфейсе бота, включая действия вида "spam:123" и
+    # кнопки меню ("menu_main", "settings_policy" и т.д.).
     app.add_handler(
         CallbackQueryHandler(
             on_callback,

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -1237,5 +1237,10 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("checkword", cmd_checkword))
 
     # Обработчики callback-ов и сообщений (расширенные паттерны)
-    app.add_handler(CallbackQueryHandler(on_callback, pattern="^(spam|ham|confirm_mod|cancel_mod|menu_|settings_|policy_|mod_|prof_|add_word|cancel_action|logs_full):"))
+    app.add_handler(
+        CallbackQueryHandler(
+            on_callback,
+            pattern=r"^(spam:|ham:|confirm_mod:|cancel_mod:|add_word:|menu_|settings_|policy_|mod_|prof_|cancel_action|logs_full)"
+        )
+    )
     app.add_handler(MessageHandler(filters.TEXT | filters.CaptionRegex(".*"), on_message))


### PR DESCRIPTION
## Summary
- adjust regex for inline keyboard callback handler

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e8e5e30388329afb9878366860ee0